### PR TITLE
Added Skip() to lean up grpc logger logs

### DIFF
--- a/otelcol/internal/grpclog/logger.go
+++ b/otelcol/internal/grpclog/logger.go
@@ -27,7 +27,7 @@ func SetLogger(baseLogger *zap.Logger, loglevel zapcore.Level) *zapgrpc.Logger {
 			c = core
 		}
 		return c.With([]zapcore.Field{zap.Bool("grpc_log", true)})
-	})))
+	}), zap.AddCallerSkip(5)))
 
 	grpclog.SetLoggerV2(logger)
 	return logger


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Added AddCallerSkip() to cleanup logger so now it logs actual locations of the log statements that are being printed instead of zapgrpc/zapgrpc.go:176
<!-- Issue number if applicable -->
#### Link to tracking issue
Fixes #10772



<!--Please delete paragraphs that you did not use before submitting.-->
